### PR TITLE
품목 관련 API 구현 완료

### DIFF
--- a/src/main/java/erp/greenagro/greenagro_erp_backend/controller/ProductController.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/controller/ProductController.java
@@ -1,13 +1,50 @@
 package erp.greenagro.greenagro_erp_backend.controller;
 
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupRequest;
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupResponse;
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.ProductGroupDTO;
 import erp.greenagro.greenagro_erp_backend.service.ProductService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 public class ProductController {
 
     private final ProductService productService;
+
+    //품목 그룹 생성
+    @PostMapping("/product-groups")
+    public ResponseEntity<CreateProductGroupResponse> createProductGroup(@RequestBody CreateProductGroupRequest request){
+        CreateProductGroupResponse response = productService.createGroup(request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    //품목 그룹 전체 조회
+    @GetMapping("/product-groups")
+    public ResponseEntity<List<ProductGroupDTO>> getAllProductGroup(){
+        List<ProductGroupDTO> responses = productService.getAllGroups();
+        return ResponseEntity.ok(responses);
+    }
+
+
+    //품목 그룹 수정
+    @PutMapping("/product-groups/{id}")
+    public ResponseEntity<Void> updateProductGroup(@PathVariable Long id, @RequestBody ProductGroupDTO request){
+        productService.updateGroup(id,request);
+        return ResponseEntity.noContent().build();
+    }
+
+
+    //품목 그룹 삭제
+    @DeleteMapping("/product-groups/{id}")
+    public ResponseEntity<Void> deleteProductGroup(@PathVariable Long id){
+        productService.deleteGroup(id);
+        return ResponseEntity.noContent().build();
+    }
 
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/controller/ProductController.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/controller/ProductController.java
@@ -1,0 +1,13 @@
+package erp.greenagro.greenagro_erp_backend.controller;
+
+import erp.greenagro.greenagro_erp_backend.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/customer/CustomerDTO.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/customer/CustomerDTO.java
@@ -1,0 +1,13 @@
+package erp.greenagro.greenagro_erp_backend.dto.customer;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomerDTO {
+
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/CreateProductRequest.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/CreateProductRequest.java
@@ -1,0 +1,39 @@
+package erp.greenagro.greenagro_erp_backend.dto.product;
+
+import erp.greenagro.greenagro_erp_backend.model.entity.Customer;
+import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
+import erp.greenagro.greenagro_erp_backend.model.enums.DistChannel;
+import erp.greenagro.greenagro_erp_backend.model.enums.TaxType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateProductRequest {
+
+    private String imgUrl;                  //이미지 경로
+
+    private String code;                    //품목코드
+
+    private String name;                    //품목명
+
+    private String spec;                    //규격
+
+    private Long boxQuantity;               //박스 수량
+
+    private Long productGroupId;            //품목 그룹
+
+    private Long customerId;                //회사
+
+    private TaxType taxType;                //세금 타입(영,과세)
+
+    private DistChannel distChannel;        //유통 채널(계통,비계통)
+
+    private Long purchasePrice;             //매입 단가
+
+    private Long salePrice;                 //출고 단가
+
+    private String memo;                    //비고
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/CreateProductResponse.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/CreateProductResponse.java
@@ -1,11 +1,11 @@
-package erp.greenagro.greenagro_erp_backend.dto.productgroup;
+package erp.greenagro.greenagro_erp_backend.dto.product;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CreateProductGroupResponse {
+public class CreateProductResponse {
 
     private Long productId;
 

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/ProductDetailResponse.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/ProductDetailResponse.java
@@ -1,5 +1,7 @@
 package erp.greenagro.greenagro_erp_backend.dto.product;
 
+import erp.greenagro.greenagro_erp_backend.dto.customer.CustomerDTO;
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.ProductGroupDTO;
 import erp.greenagro.greenagro_erp_backend.model.entity.Customer;
 import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
 import erp.greenagro.greenagro_erp_backend.model.enums.DistChannel;
@@ -24,9 +26,9 @@ public class ProductDetailResponse {
 
     private Long boxQuantity;               //박스 수량
 
-    private ProductGroup productGroup;      //품목 그룹
+    private ProductGroupDTO productGroup;      //품목 그룹
 
-    private Customer customer;              //회사
+    private CustomerDTO customer;              //회사
 
     private TaxType taxType;                //세금 타입(영,과세)
 

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/ProductDetailResponse.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/ProductDetailResponse.java
@@ -1,0 +1,41 @@
+package erp.greenagro.greenagro_erp_backend.dto.product;
+
+import erp.greenagro.greenagro_erp_backend.model.entity.Customer;
+import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
+import erp.greenagro.greenagro_erp_backend.model.enums.DistChannel;
+import erp.greenagro.greenagro_erp_backend.model.enums.TaxType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductDetailResponse {
+
+    private Long id;
+
+    private String imgUrl;                  //이미지 경로
+
+    private String code;                    //품목코드
+
+    private String name;                    //품목명
+
+    private String spec;                    //규격
+
+    private Long boxQuantity;               //박스 수량
+
+    private ProductGroup productGroup;      //품목 그룹
+
+    private Customer customer;              //회사
+
+    private TaxType taxType;                //세금 타입(영,과세)
+
+    private DistChannel distChannel;        //유통 채널(계통,비계통)
+
+    private Long purchasePrice;             //매입 단가
+
+    private Long salePrice;                 //출고 단가
+
+    private String memo;
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/ProductSummaryResponse.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/ProductSummaryResponse.java
@@ -1,0 +1,38 @@
+package erp.greenagro.greenagro_erp_backend.dto.product;
+
+import erp.greenagro.greenagro_erp_backend.dto.customer.CustomerDTO;
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.ProductGroupDTO;
+import erp.greenagro.greenagro_erp_backend.model.entity.Customer;
+import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
+import erp.greenagro.greenagro_erp_backend.model.enums.DistChannel;
+import erp.greenagro.greenagro_erp_backend.model.enums.TaxType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductSummaryResponse {
+
+    private Long id;
+
+    private String imgUrl;                  //이미지 경로
+
+    private String code;                    //품목코드
+
+    private String name;                    //품목명
+
+    private String spec;                    //규격
+
+    private Long boxQuantity;               //박스 수량
+
+    private ProductGroupDTO productGroup;   //품목 그룹
+
+    private CustomerDTO customer;            //회사
+
+    private String taxType;                //세금 타입(영,과세)
+
+    private String distChannel;        //유통 채널(계통,비계통)
+
+    private Long salePrice;                 //출고 단가
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/UpdateProductRequest.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/product/UpdateProductRequest.java
@@ -1,0 +1,36 @@
+package erp.greenagro.greenagro_erp_backend.dto.product;
+
+import erp.greenagro.greenagro_erp_backend.model.enums.DistChannel;
+import erp.greenagro.greenagro_erp_backend.model.enums.TaxType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UpdateProductRequest {
+
+    private String imgUrl;                  //이미지 경로
+
+    private String code;                    //품목코드
+
+    private String name;                    //품목명
+
+    private String spec;                    //규격
+
+    private Long boxQuantity;               //박스 수량
+
+    private Long productGroupId;            //품목 그룹
+
+    private Long customerId;                //회사
+
+    private TaxType taxType;                //세금 타입(영,과세)
+
+    private DistChannel distChannel;        //유통 채널(계통,비계통)
+
+    private Long purchasePrice;             //매입 단가
+
+    private Long salePrice;                 //출고 단가
+
+    private String memo;                    //비고
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/productgroup/CreateProductGroupRequest.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/productgroup/CreateProductGroupRequest.java
@@ -1,0 +1,12 @@
+package erp.greenagro.greenagro_erp_backend.dto.productgroup;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateProductGroupRequest {
+
+    private String name;
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/productgroup/CreateProductGroupResponse.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/productgroup/CreateProductGroupResponse.java
@@ -1,0 +1,12 @@
+package erp.greenagro.greenagro_erp_backend.dto.productgroup;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateProductGroupResponse {
+
+    private Long id;
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/dto/productgroup/ProductGroupDTO.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/dto/productgroup/ProductGroupDTO.java
@@ -1,0 +1,13 @@
+package erp.greenagro.greenagro_erp_backend.dto.productgroup;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductGroupDTO {
+
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/Product.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/Product.java
@@ -25,11 +25,11 @@ public class Product {
 
     private Long boxQuantity;               //박스 수량
 
-    @ManyToOne(fetch = FetchType.LAZY,optional = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "product_group_id")
     private ProductGroup productGroup;      //품목 그룹
 
-    @ManyToOne(fetch = FetchType.LAZY,optional = false)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "customer_id")
     private Customer customer;              //회사
 
@@ -47,4 +47,43 @@ public class Product {
 
     private boolean deleted;                //삭제여부
 
+
+    public Product(String imgUrl, String code, String name, String spec, Long boxQuantity, ProductGroup productGroup, Customer customer, TaxType taxType, DistChannel distChannel, Long purchasePrice, Long salePrice, String memo) {
+        this.imgUrl = imgUrl;
+        this.code = code;
+        this.name = name;
+        this.spec = spec;
+        this.boxQuantity = boxQuantity;
+        this.productGroup = productGroup;
+        this.customer = customer;
+        this.taxType = taxType;
+        this.distChannel = distChannel;
+        this.purchasePrice = purchasePrice;
+        this.salePrice = salePrice;
+        this.memo = memo;
+    }
+
+
+
+    //수정하기
+    public void update(String imgUrl, String code, String name, String spec, Long boxQuantity, ProductGroup productGroup, Customer customer, TaxType taxType, DistChannel distChannel, Long purchasePrice, Long salePrice, String memo) {
+        this.imgUrl = imgUrl;
+        this.code = code;
+        this.name = name;
+        this.spec = spec;
+        this.boxQuantity = boxQuantity;
+        this.productGroup = productGroup;
+        this.customer = customer;
+        this.taxType = taxType;
+        this.distChannel = distChannel;
+        this.purchasePrice = purchasePrice;
+        this.salePrice = salePrice;
+        this.memo = memo;
+    }
+
+
+    //삭제하기
+    public void delete(){
+        this.deleted = true;
+    }
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/Product.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/Product.java
@@ -1,0 +1,48 @@
+package erp.greenagro.greenagro_erp_backend.model.entity;
+
+import erp.greenagro.greenagro_erp_backend.model.enums.DistChannel;
+import erp.greenagro.greenagro_erp_backend.model.enums.TaxType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Product {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String imgUrl;                  //이미지 경로
+
+    private String code;                    //품목코드
+
+    private String name;                    //품목명
+
+    private String spec;                    //규격
+
+    private Long boxQuantity;               //박스 수량
+
+    @ManyToOne(fetch = FetchType.LAZY,optional = false)
+    @JoinColumn(name = "product_group_id")
+    private ProductGroup productGroup;      //품목 그룹
+
+    @ManyToOne(fetch = FetchType.LAZY,optional = false)
+    @JoinColumn(name = "customer_id")
+    private Customer customer;              //회사
+
+    @Enumerated(EnumType.STRING)
+    private TaxType taxType;                //세금 타입(영,과세)
+
+    @Enumerated(EnumType.STRING)
+    private DistChannel distChannel;        //유통 채널(계통,비계통)
+
+    private Long purchasePrice;             //매입 단가
+
+    private Long salePrice;                 //출고 단가
+
+    private String memo;                    //비고
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/Product.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/Product.java
@@ -45,4 +45,6 @@ public class Product {
 
     private String memo;                    //비고
 
+    private boolean deleted;                //삭제여부
+
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/ProductGroup.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/ProductGroup.java
@@ -1,0 +1,21 @@
+package erp.greenagro.greenagro_erp_backend.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductGroup {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;    //그룹 이름
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/ProductGroup.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/model/entity/ProductGroup.java
@@ -16,6 +16,22 @@ public class ProductGroup {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;    //그룹 이름
+    private String name;        //그룹 이름
 
+    private boolean deleted;   //삭제 여부
+
+
+    public ProductGroup(String name) {
+        this.name = name;
+    }
+
+    //수정하기
+    public void update(String name){
+        this.name = name;
+    }
+
+    //삭제하기
+    public void delete(){
+        this.deleted = true;
+    }
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/model/enums/DistChannel.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/model/enums/DistChannel.java
@@ -1,0 +1,10 @@
+package erp.greenagro.greenagro_erp_backend.model.enums;
+
+public enum DistChannel {
+
+    NH_COOP,      // 농협 계통
+    NON_COOP,     // 비계통
+    DIRECT,       // 직송
+    SPECIAL       // 특판
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/model/enums/TaxType.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/model/enums/TaxType.java
@@ -1,0 +1,10 @@
+package erp.greenagro.greenagro_erp_backend.model.enums;
+
+public enum TaxType {
+
+    TAXED,      //과세
+    ZERO,       //영세
+    EXEMPT,     //면세
+    NON_TAX     //비과세
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/repository/CustomerRepository.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/repository/CustomerRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
     List<Customer> findAllByDeletedFalse();
+
+    Optional<Customer> findByIdAndDeletedFalse(Long id);
 
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductGroupRepository.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductGroupRepository.java
@@ -1,8 +1,18 @@
 package erp.greenagro.greenagro_erp_backend.repository;
 
+import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
-public interface ProductGroupRepository extends JpaRepository<ProductGroupRepository, Long> {
+public interface ProductGroupRepository extends JpaRepository<ProductGroup, Long> {
+    boolean existsByNameAndDeletedFalse(String name);
+
+    List<ProductGroup> findAllByDeletedFalse();
+
+    Optional<ProductGroup> findByIdAndDeletedFalse(Long id);
+
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductGroupRepository.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductGroupRepository.java
@@ -1,0 +1,8 @@
+package erp.greenagro.greenagro_erp_backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductGroupRepository extends JpaRepository<ProductGroupRepository, Long> {
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductRepository.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductRepository.java
@@ -1,0 +1,9 @@
+package erp.greenagro.greenagro_erp_backend.repository;
+
+import erp.greenagro.greenagro_erp_backend.model.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductRepository.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductRepository.java
@@ -1,9 +1,12 @@
 package erp.greenagro.greenagro_erp_backend.repository;
 
 import erp.greenagro.greenagro_erp_backend.model.entity.Product;
+import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+    boolean existsByProductGroupAndDeletedFalse(ProductGroup productGroup);
+
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductRepository.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductRepository.java
@@ -16,8 +16,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     Optional<Product> findByIdAndDeletedFalse(Long id);
 
-    boolean existsByCode(String code);
+    boolean existsByCodeAndDeletedFalse(String code);
 
-    boolean existsByName(String name);
+    boolean existsByNameAndDeletedFalse(String name);
 
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductRepository.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/repository/ProductRepository.java
@@ -5,8 +5,19 @@ import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
     boolean existsByProductGroupAndDeletedFalse(ProductGroup productGroup);
+
+    List<Product> findAllByDeletedFalse();
+
+    Optional<Product> findByIdAndDeletedFalse(Long id);
+
+    boolean existsByCode(String code);
+
+    boolean existsByName(String name);
 
 }

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/service/ProductService.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/service/ProductService.java
@@ -30,20 +30,20 @@ public class ProductService {
     @Transactional
     public CreateProductResponse createProduct(CreateProductRequest request){
         //1. 검증 및 중복확인
-        if(productRepository.existsByCode(request.getCode()))
+        if(productRepository.existsByCodeAndDeletedFalse(request.getCode()))
             throw new IllegalArgumentException("중복된 품목 코드 입니다. code:"+request.getCode());
-        if(productRepository.existsByName(request.getName()))
+        if(productRepository.existsByNameAndDeletedFalse(request.getName()))
             throw new IllegalArgumentException("중복된 품목명 입니다. name:"+request.getName());
-        /**
-         * 문제 1) 그룹과 회사가 null일떄
-         * 문제 2) findById 인데 논리 삭제일땐 delete=false 적용해야함
-         */
 
         //2. 품목 그룹 조회
-        ProductGroup productGroup = productGroupRepository.findById(request.getProductGroupId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목그룹입니다. id:" + request.getProductGroupId()));
+        ProductGroup productGroup = null;
+        if(request.getProductGroupId() != null)
+            productGroup = productGroupRepository.findByIdAndDeletedFalse(request.getProductGroupId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목그룹입니다. id:" + request.getProductGroupId()));
 
         //3. 회사 조회
-        Customer customer = customerRepository.findById(request.getCustomerId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 고객입니다. id:" + request.getCustomerId()));
+        Customer customer = null;
+        if(request.getCustomerId() != null)
+            customer = customerRepository.findByIdAndDeletedFalse(request.getCustomerId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 고객입니다. id:" + request.getCustomerId()));
 
         //4. 엔티티 생성
         Product product = new Product(
@@ -77,21 +77,20 @@ public class ProductService {
         Product product = productRepository.findByIdAndDeletedFalse(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목입니다. id:" + id));
 
         //2. 검증 및 중복확인
-        if(!product.getCode().equals(request.getCode()) && productRepository.existsByCode(request.getCode()))
+        if(!product.getCode().equals(request.getCode()) && productRepository.existsByCodeAndDeletedFalse(request.getCode()))
             throw new IllegalArgumentException("중복된 품목 코드 입니다. code:"+request.getCode());
-        if(!product.getName().equals(request.getName()) && productRepository.existsByName(request.getName()))
+        if(!product.getName().equals(request.getName()) && productRepository.existsByNameAndDeletedFalse(request.getName()))
             throw new IllegalArgumentException("중복된 품목명 입니다. name:"+request.getName());
 
-        /**
-         * 문제 1) 그룹과 회사가 null일떄
-         * 문제 2) findById 인데 논리 삭제일땐 delete=false 적용해야함
-         */
-
         //3. 품목 그룹 조회
-        ProductGroup productGroup = productGroupRepository.findById(request.getProductGroupId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목그룹입니다. id:" + request.getProductGroupId()));
+        ProductGroup productGroup = null;
+        if(request.getProductGroupId() != null)
+            productGroup = productGroupRepository.findByIdAndDeletedFalse(request.getProductGroupId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목그룹입니다. id:" + request.getProductGroupId()));
 
         //4. 회사 조회
-        Customer customer = customerRepository.findById(request.getCustomerId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 고객입니다. id:" + request.getCustomerId()));
+        Customer customer = null;
+        if(request.getCustomerId() != null)
+            customer = customerRepository.findByIdAndDeletedFalse(request.getCustomerId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 고객입니다. id:" + request.getCustomerId()));
 
 
         //5. 수정하기
@@ -155,8 +154,8 @@ public class ProductService {
                 product.getName(),
                 product.getSpec(),
                 product.getBoxQuantity(),
-                product.getProductGroup(),
-                product.getCustomer(),
+                new ProductGroupDTO(product.getProductGroup().getId(), product.getProductGroup().getName()),
+                new CustomerDTO(product.getCustomer().getId(), product.getCustomer().getBizName()),
                 product.getTaxType(),
                 product.getDistChannel(),
                 product.getPurchasePrice(),

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/service/ProductService.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/service/ProductService.java
@@ -1,9 +1,14 @@
 package erp.greenagro.greenagro_erp_backend.service;
 
+import erp.greenagro.greenagro_erp_backend.dto.customer.CustomerDTO;
+import erp.greenagro.greenagro_erp_backend.dto.product.*;
 import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupRequest;
 import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupResponse;
 import erp.greenagro.greenagro_erp_backend.dto.productgroup.ProductGroupDTO;
+import erp.greenagro.greenagro_erp_backend.model.entity.Customer;
+import erp.greenagro.greenagro_erp_backend.model.entity.Product;
 import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
+import erp.greenagro.greenagro_erp_backend.repository.CustomerRepository;
 import erp.greenagro.greenagro_erp_backend.repository.ProductGroupRepository;
 import erp.greenagro.greenagro_erp_backend.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,17 +23,157 @@ public class ProductService {
 
     private final ProductRepository productRepository;
     private final ProductGroupRepository productGroupRepository;
+    private final CustomerRepository customerRepository;
 
 
     //품목 생성
+    @Transactional
+    public CreateProductResponse createProduct(CreateProductRequest request){
+        //1. 검증 및 중복확인
+        if(productRepository.existsByCode(request.getCode()))
+            throw new IllegalArgumentException("중복된 품목 코드 입니다. code:"+request.getCode());
+        if(productRepository.existsByName(request.getName()))
+            throw new IllegalArgumentException("중복된 품목명 입니다. name:"+request.getName());
+        /**
+         * 문제 1) 그룹과 회사가 null일떄
+         * 문제 2) findById 인데 논리 삭제일땐 delete=false 적용해야함
+         */
+
+        //2. 품목 그룹 조회
+        ProductGroup productGroup = productGroupRepository.findById(request.getProductGroupId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목그룹입니다. id:" + request.getProductGroupId()));
+
+        //3. 회사 조회
+        Customer customer = customerRepository.findById(request.getCustomerId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 고객입니다. id:" + request.getCustomerId()));
+
+        //4. 엔티티 생성
+        Product product = new Product(
+                request.getImgUrl(),
+                request.getCode(),
+                request.getName(),
+                request.getSpec(),
+                request.getBoxQuantity(),
+                productGroup,
+                customer,
+                request.getTaxType(),
+                request.getDistChannel(),
+                request.getPurchasePrice(),
+                request.getSalePrice(),
+                request.getMemo()
+        );
+
+        //5. 저장
+        productRepository.save(product);
+
+        //6. id 반한
+        return new CreateProductResponse(product.getId());
+    }
+
 
     //품목 수정
+    @Transactional
+    public void updateProduct(Long id, UpdateProductRequest request){
+
+        //1. 해당 품목 조회
+        Product product = productRepository.findByIdAndDeletedFalse(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목입니다. id:" + id));
+
+        //2. 검증 및 중복확인
+        if(!product.getCode().equals(request.getCode()) && productRepository.existsByCode(request.getCode()))
+            throw new IllegalArgumentException("중복된 품목 코드 입니다. code:"+request.getCode());
+        if(!product.getName().equals(request.getName()) && productRepository.existsByName(request.getName()))
+            throw new IllegalArgumentException("중복된 품목명 입니다. name:"+request.getName());
+
+        /**
+         * 문제 1) 그룹과 회사가 null일떄
+         * 문제 2) findById 인데 논리 삭제일땐 delete=false 적용해야함
+         */
+
+        //3. 품목 그룹 조회
+        ProductGroup productGroup = productGroupRepository.findById(request.getProductGroupId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목그룹입니다. id:" + request.getProductGroupId()));
+
+        //4. 회사 조회
+        Customer customer = customerRepository.findById(request.getCustomerId()).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 고객입니다. id:" + request.getCustomerId()));
+
+
+        //5. 수정하기
+        product.update(
+                request.getImgUrl(),
+                request.getCode(),
+                request.getName(),
+                request.getSpec(),
+                request.getBoxQuantity(),
+                productGroup,
+                customer,
+                request.getTaxType(),
+                request.getDistChannel(),
+                request.getPurchasePrice(),
+                request.getSalePrice(),
+                request.getMemo()
+        );
+    }
+
 
     //품목 전체 조회
+    @Transactional(readOnly = true)
+    public List<ProductSummaryResponse> getAllProducts(){
+        //1. 전체 조회 (deleted = false)
+        List<Product> products = productRepository.findAllByDeletedFalse();
 
-    //품목 단건 조회
+        //2. DTO 변환
+        return products.stream().map(product -> {
+
+            ProductGroup group = product.getProductGroup();
+            Customer customer = product.getCustomer();
+
+            return new ProductSummaryResponse(
+                    product.getId(),
+                    product.getImgUrl(),
+                    product.getCode(),
+                    product.getName(),
+                    product.getSpec(),
+                    product.getBoxQuantity(),
+                    new ProductGroupDTO(group.getId(), group.getName()),
+                    new CustomerDTO(customer.getId(), customer.getBizName()),
+                    product.getTaxType().toString(),
+                    product.getDistChannel().toString(),
+                    product.getSalePrice()
+            );
+        }).toList();
+    }
+
+
+    //품목 상세 조회
+    @Transactional(readOnly = true)
+    public ProductDetailResponse getProduct(Long id){
+        //1. 해당 품목 조회
+        Product product = productRepository.findByIdAndDeletedFalse(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 품목입니다. id:" + id));
+
+        //2. dto 변환
+        return new ProductDetailResponse(
+                product.getId(),
+                product.getImgUrl(),
+                product.getCode(),
+                product.getName(),
+                product.getSpec(),
+                product.getBoxQuantity(),
+                product.getProductGroup(),
+                product.getCustomer(),
+                product.getTaxType(),
+                product.getDistChannel(),
+                product.getPurchasePrice(),
+                product.getSalePrice(),
+                product.getMemo()
+        );
+    }
+
 
     //품목 삭제 <- 논리 삭제
+    @Transactional
+    public void deleteProduct(Long id){
+        //1. 해당 품목 조회
+        Product product = productRepository.findByIdAndDeletedFalse(id).orElseThrow(()-> new IllegalArgumentException("해당 품목을 찾을 수 없습니다. id:"+id));
+        //2. 삭제처리
+        product.delete();
+    }
 
 
 
@@ -68,7 +213,7 @@ public class ProductService {
     //전체 그룹 조회
     @Transactional(readOnly = true)
     public List<ProductGroupDTO> getAllGroups(){
-        //전체 조회
+        //전체 조회(deleted = false)
         List<ProductGroup> groups = productGroupRepository.findAllByDeletedFalse();
 
         //dto 변환

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/service/ProductService.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/service/ProductService.java
@@ -1,0 +1,13 @@
+package erp.greenagro.greenagro_erp_backend.service;
+
+import erp.greenagro.greenagro_erp_backend.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+}

--- a/src/main/java/erp/greenagro/greenagro_erp_backend/service/ProductService.java
+++ b/src/main/java/erp/greenagro/greenagro_erp_backend/service/ProductService.java
@@ -1,13 +1,99 @@
 package erp.greenagro.greenagro_erp_backend.service;
 
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupRequest;
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupResponse;
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.ProductGroupDTO;
+import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
+import erp.greenagro.greenagro_erp_backend.repository.ProductGroupRepository;
 import erp.greenagro.greenagro_erp_backend.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ProductService {
 
     private final ProductRepository productRepository;
+    private final ProductGroupRepository productGroupRepository;
+
+
+    //품목 생성
+
+    //품목 수정
+
+    //품목 전체 조회
+
+    //품목 단건 조회
+
+    //품목 삭제 <- 논리 삭제
+
+
+
+    //그룹 생성
+    @Transactional
+    public CreateProductGroupResponse createGroup(CreateProductGroupRequest request){
+        //1. 검증 및 중복검사
+        if(productGroupRepository.existsByNameAndDeletedFalse(request.getName()))
+            throw new IllegalArgumentException("중복된 품목그룹명 입니다. 이름:"+request.getName());
+
+        //2. 엔티티 생성
+        ProductGroup productGroup = new ProductGroup(request.getName());
+
+        //3. 저장
+        productGroupRepository.save(productGroup);
+
+        //4. id 반환
+        return new CreateProductGroupResponse(productGroup.getId());
+    }
+
+
+    //그룹 수정
+    @Transactional
+    public void updateGroup(Long id, ProductGroupDTO request){
+        //1. 해당 품목그룹 조회
+        ProductGroup productGroup = productGroupRepository.findByIdAndDeletedFalse(id).orElseThrow(()->new IllegalArgumentException("존재하지 않는 품목그룹입니다. id:" + request.getId()));
+
+        //2. 검증 및 중복검사
+        if(!productGroup.getName().equals(request.getName()) && productGroupRepository.existsByNameAndDeletedFalse(request.getName()))
+            throw new IllegalArgumentException("중복된 품목그룹명 입니다. 이름:"+request.getName());
+
+        //3. 업데이트
+        productGroup.update(request.getName());
+    }
+
+
+    //전체 그룹 조회
+    @Transactional(readOnly = true)
+    public List<ProductGroupDTO> getAllGroups(){
+        //전체 조회
+        List<ProductGroup> groups = productGroupRepository.findAllByDeletedFalse();
+
+        //dto 변환
+        return groups.stream().map(group ->
+                new ProductGroupDTO(
+                        group.getId(),
+                        group.getName()
+                )
+        ).toList();
+    }
+
+
+    //그룹 삭제
+    @Transactional
+    public void deleteGroup(Long id){
+        //1. 해당 품목그룹 조회
+        ProductGroup productGroup = productGroupRepository.findByIdAndDeletedFalse(id).orElseThrow(()->new IllegalArgumentException("존재하지 않는 품목그룹입니다. id:" + id));
+
+        //2. 상품 있으면 삭제 불가 <- 나중에 자세히 리스트업 하기
+        if(productRepository.existsByProductGroupAndDeletedFalse(productGroup))
+            throw new IllegalArgumentException("해당 품목 그룹에 해당하는 품목이 있어서 삭제가 불가능합니다. ");
+
+        //3. 삭제
+        productGroup.delete();
+    }
+
 
 }

--- a/src/test/java/erp/greenagro/greenagro_erp_backend/service/ProductServiceTest.java
+++ b/src/test/java/erp/greenagro/greenagro_erp_backend/service/ProductServiceTest.java
@@ -1,0 +1,151 @@
+package erp.greenagro.greenagro_erp_backend.service;
+
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupRequest;
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupResponse;
+import erp.greenagro.greenagro_erp_backend.dto.productgroup.ProductGroupDTO;
+import erp.greenagro.greenagro_erp_backend.model.entity.Product;
+import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
+import erp.greenagro.greenagro_erp_backend.repository.ProductGroupRepository;
+import erp.greenagro.greenagro_erp_backend.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class ProductServiceTest {
+
+    @Autowired
+    ProductRepository productRepository;
+    @Autowired
+    ProductService productService;
+    @Autowired
+    ProductGroupRepository productGroupRepository;
+
+    /**
+         그룹 생성 createGroup()
+         1.이름 중복 불가
+         2.deleted = true 인 항목과는 중복 허용
+
+         그룹 수정 updateGroup()
+         1.이름 중복 불가
+         2.deleted = true 인 항목과는 중복 허용
+
+         전체 그룹 조회 getAllGroups()
+         1.전체 조회 가능
+         2.deleted = true 인 항목은 제외
+
+         그룹 삭제 deleteGroup()
+         1.논리 삭제 (deleted = true 처리)
+     **/
+
+    @Test
+    void 그룹_생성_정상(){
+        //given
+        CreateProductGroupRequest request = new CreateProductGroupRequest("농약");
+
+        //when
+        CreateProductGroupResponse response = productService.createGroup(request);
+
+        //then
+        ProductGroup group = productGroupRepository.findById(response.getProductId()).orElseThrow();
+        assertNotNull(response.getProductId());
+        assertEquals(request.getName(), group.getName());
+        assertFalse(group.isDeleted());
+    }
+
+
+    @Test
+    void 그룹_생성_이름_중복(){
+        //given
+        CreateProductGroupRequest request = new CreateProductGroupRequest("농약");
+        CreateProductGroupRequest requestDuplicateName = new CreateProductGroupRequest("농약");
+
+        //when
+        CreateProductGroupResponse response = productService.createGroup(request);
+
+        //then
+        assertThrows(IllegalArgumentException.class, () -> productService.createGroup(requestDuplicateName));
+    }
+
+
+    @Test
+    void 그룹_생성_삭제된_이름_중복허용(){
+        //given
+        CreateProductGroupRequest request = new CreateProductGroupRequest("농약");
+        CreateProductGroupRequest requestDuplicateName = new CreateProductGroupRequest("농약");
+
+        //when
+        CreateProductGroupResponse response = productService.createGroup(request); //생성
+        productService.deleteGroup(response.getProductId()); //삭제
+
+        //then
+        productService.createGroup(requestDuplicateName); // 중복 가능
+    }
+
+
+    @Test
+    void 그룹_조회_전체(){
+        //given
+        Map<Long, ProductGroup> map = new HashMap<>();
+
+        ProductGroup group1 = productGroupRepository.save(new ProductGroup("농약"));
+        ProductGroup group2 = productGroupRepository.save(new ProductGroup("씨앗"));
+        ProductGroup deletedGroup = productGroupRepository.save(new ProductGroup("자재"));
+
+        map.put(group1.getId(), group1);
+        map.put(group2.getId(), group2);
+
+        productService.deleteGroup(deletedGroup.getId());
+
+        //when
+        List<ProductGroupDTO> responses = productService.getAllGroups();
+
+
+        //then
+        assertEquals(2, responses.size());
+
+        responses.stream().forEach(res -> {
+            ProductGroup group = map.get(res.getId());
+            assertEquals(group.getId(), res.getId());
+            assertEquals(group.getName(), res.getName());
+        });
+    }
+
+
+    @Test
+    void 그룹_삭제(){
+        //given
+        ProductGroup group = productGroupRepository.save(new ProductGroup("농약"));
+
+        //when
+        productService.deleteGroup(group.getId());
+
+        //then
+        assertTrue(group.isDeleted());
+    }
+
+    @Test
+    void 그룹_삭제_품목존재시_불가(){
+        //given
+        ProductGroup group = productGroupRepository.save(new ProductGroup("농약"));
+        Product product = productRepository.save(new Product("http://img/1", "123", "테스트 품목", "10L", 10L, group, null, null, null, null, null, null));
+
+        //when - then - 품목이 있어서 그룹 삭제 불가
+        assertThrows(IllegalArgumentException.class, () -> productService.deleteGroup(group.getId()));
+
+        //when - 품목 지우기
+        product.delete();
+        //then - 그룹에 속한 품목이 없어서 삭제 가능!
+        productService.deleteGroup(group.getId());
+    }
+
+}

--- a/src/test/java/erp/greenagro/greenagro_erp_backend/service/ProductServiceTest.java
+++ b/src/test/java/erp/greenagro/greenagro_erp_backend/service/ProductServiceTest.java
@@ -1,10 +1,17 @@
 package erp.greenagro.greenagro_erp_backend.service;
 
+import erp.greenagro.greenagro_erp_backend.dto.product.*;
 import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupRequest;
 import erp.greenagro.greenagro_erp_backend.dto.productgroup.CreateProductGroupResponse;
 import erp.greenagro.greenagro_erp_backend.dto.productgroup.ProductGroupDTO;
+import erp.greenagro.greenagro_erp_backend.model.entity.Customer;
 import erp.greenagro.greenagro_erp_backend.model.entity.Product;
 import erp.greenagro.greenagro_erp_backend.model.entity.ProductGroup;
+import erp.greenagro.greenagro_erp_backend.model.enums.CustomerType;
+import erp.greenagro.greenagro_erp_backend.model.enums.DistChannel;
+import erp.greenagro.greenagro_erp_backend.model.enums.SalesGroup;
+import erp.greenagro.greenagro_erp_backend.model.enums.TaxType;
+import erp.greenagro.greenagro_erp_backend.repository.CustomerRepository;
 import erp.greenagro.greenagro_erp_backend.repository.ProductGroupRepository;
 import erp.greenagro.greenagro_erp_backend.repository.ProductRepository;
 import org.junit.jupiter.api.Test;
@@ -26,9 +33,280 @@ class ProductServiceTest {
     @Autowired
     ProductRepository productRepository;
     @Autowired
+    ProductGroupRepository productGroupRepository;
+    @Autowired
     ProductService productService;
     @Autowired
-    ProductGroupRepository productGroupRepository;
+    CustomerRepository customerRepository;
+
+
+
+    /**
+        품목 생성 createProduct()
+        1. 이름, 코드 중복 불가
+        2. deleted = true 인 항목과는 중복 허용
+        3. customer, productGroup 요청 없을때도 가능
+        4. customer, productGroup 요청은 있는데 조회시 없는경우 -> 오류
+
+        품목 수정 updateProduct()
+         1. 이름, 코드 중복 불가 (자기 스스로는 가능)
+         2. deleted = true 인 항목과는 중복 허용
+         3. customer, productGroup 요청 없을때도 가능
+         4. customer, productGroup 요청은 있는데 조회시 없는경우 -> 오류
+
+        품목 전체 조회 getAllProducts()
+        1.전체 조회 가능
+
+        품목 상세 조회 getProduct()
+        1. 품목 상세 조회
+        2. 품목 존재 x -> 오류
+
+        품목 삭제 deleteProduct()
+        1. 논리 삭제 (deleted = true 처리)
+     **/
+    @Test
+    void 품목_생성_정상(){
+        //given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+        CreateProductRequest request = getCreateProductRequest("001","테스트품목", group, customer);
+
+
+        //when
+        CreateProductResponse response = productService.createProduct(request);
+
+
+        //then
+        Product product = productRepository.findById(response.getProductId()).orElseThrow();
+        assertEquals(product.getId(), response.getProductId());
+        assertEquals(request.getImgUrl(), product.getImgUrl());
+        assertEquals(request.getCode(), product.getCode());
+        assertEquals(request.getName(), product.getName());
+        assertEquals(request.getSpec(), product.getSpec());
+        assertEquals(request.getBoxQuantity(), product.getBoxQuantity());
+        assertEquals(group, product.getProductGroup());//jpa 영속성
+        assertEquals(request.getProductGroupId(), product.getProductGroup().getId());
+        assertEquals(customer, product.getCustomer()); //jpa 영속성
+        assertEquals(request.getCustomerId(), product.getCustomer().getId());
+        assertEquals(request.getTaxType(), product.getTaxType());
+        assertEquals(request.getDistChannel(), product.getDistChannel());
+        assertEquals(request.getPurchasePrice(), product.getPurchasePrice());
+        assertEquals(request.getSalePrice(), product.getSalePrice());
+        assertEquals(request.getMemo(), product.getMemo());
+    }
+
+
+    @Test
+    void 품목_생성_이름_코드_중복(){
+        //given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+
+        CreateProductRequest request = getCreateProductRequest("P001","상품A", group, customer);
+        CreateProductRequest requestDuplicateCode = getCreateProductRequest("P001","상품B", group, customer);
+        CreateProductRequest requestDuplicateName = getCreateProductRequest("P002","상품A", group, customer);
+        CreateProductRequest requestDuplicateAll = getCreateProductRequest("P001","상품A", group, customer);
+
+
+        //when
+        productService.createProduct(request);
+
+        //then
+        assertThrows(IllegalArgumentException.class, () -> productService.createProduct(requestDuplicateCode));
+        assertThrows(IllegalArgumentException.class, () -> productService.createProduct(requestDuplicateName));
+        assertThrows(IllegalArgumentException.class, () -> productService.createProduct(requestDuplicateAll));
+    }
+
+
+    @Test
+    void 품목_생성_논리삭제된_이름_코드_중복허용(){
+        //given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+
+        CreateProductRequest request = getCreateProductRequest("P001","상품A", group, customer);
+        CreateProductRequest requestDuplicateAll = getCreateProductRequest("P001","상품A", group, customer);
+
+
+        //when
+        CreateProductResponse product = productService.createProduct(request); //저장
+        productService.deleteProduct(product.getProductId()); //논리삭제
+
+        //then
+        productService.createProduct(requestDuplicateAll);
+    }
+
+
+    @Test
+    void 품목_생성_회사_그룹_null_가능(){
+        //given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+        CreateProductRequest request = getCreateProductRequest("P001","상품A", group, customer);
+
+        //when-then 정상 저장 (Customer, ProductGroup 필수 아님)
+        productService.createProduct(request);
+    }
+
+
+    @Test
+    void 품목_수정_정상(){
+        //given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+        Product beforeProduct = getProductAndSave("P001", "품목A", group, customer); //나중에 null일때도 테스트
+
+        Customer customer2 = customerRepository.save(getCustomer2());
+        ProductGroup group2 = productGroupRepository.save(new ProductGroup("테스트 그룹2"));
+        UpdateProductRequest request = getUpdateProductRequest("P002", "품목B", group2, customer2);
+
+
+        //when
+        productService.updateProduct(beforeProduct.getId(), request);
+
+
+        //then
+        Product afterProduct = productRepository.findById(beforeProduct.getId()).orElseThrow();
+        assertEquals(request.getImgUrl(), afterProduct.getImgUrl());
+        assertEquals(request.getCode(), afterProduct.getCode());
+        assertEquals(request.getName(), afterProduct.getName());
+        assertEquals(request.getSpec(), afterProduct.getSpec());
+        assertEquals(request.getBoxQuantity(), afterProduct.getBoxQuantity());
+        assertEquals(request.getProductGroupId(), afterProduct.getProductGroup() != null ? afterProduct.getProductGroup().getId() : null);
+        assertEquals(request.getCustomerId(), afterProduct.getCustomer() != null ? afterProduct.getCustomer().getId() : null);
+        assertEquals(request.getTaxType(), afterProduct.getTaxType());
+        assertEquals(request.getDistChannel(), afterProduct.getDistChannel());
+        assertEquals(request.getPurchasePrice(), afterProduct.getPurchasePrice());
+        assertEquals(request.getSalePrice(), afterProduct.getSalePrice());
+        assertEquals(request.getMemo(), afterProduct.getMemo());
+    }
+
+
+    @Test
+    void 품목_수정_코드_이름_중복(){
+        //given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+
+        Product existingProduct = getProductAndSave("P001", "품목A", group, customer); //나중에 null일때도 테스트
+
+        Product targetProduct = getProductAndSave("P002", "품목B", group, customer); //나중에 null일때도 테스트
+
+        UpdateProductRequest requestDuplicateCode = getUpdateProductRequest("P001", "품목B", group, customer);
+        UpdateProductRequest requestDuplicateName = getUpdateProductRequest("P002", "품목A", group, customer);
+        UpdateProductRequest requestDuplicateAll = getUpdateProductRequest("P001", "품목A", group, customer);
+
+
+        //when-then
+        assertThrows(IllegalArgumentException.class, () ->  productService.updateProduct(targetProduct.getId(), requestDuplicateCode));
+        assertThrows(IllegalArgumentException.class, () ->  productService.updateProduct(targetProduct.getId(), requestDuplicateName));
+        assertThrows(IllegalArgumentException.class, () ->  productService.updateProduct(targetProduct.getId(), requestDuplicateAll));
+    }
+
+
+    @Test
+    void 품목_수정_회사_그룹_null_가능(){
+        //given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+
+        Product beforeProduct = getProductAndSave("P001", "품목A", group, customer); //나중에 null일때도 테스트
+
+        UpdateProductRequest request = getUpdateProductRequest("P001", "품목A", null, null);
+
+
+        //when
+        productService.updateProduct(beforeProduct.getId(), request);
+
+
+        //then
+        Product afterProduct = productRepository.findById(beforeProduct.getId()).orElseThrow();
+        assertNull(afterProduct.getProductGroup());
+        assertNull(afterProduct.getCustomer());
+    }
+
+
+    @Test
+    void 품목_전체_조회(){
+        // given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+        List<Product> savedProducts = List.of(
+                productRepository.save(getProductAndSave("001","품목1", group, customer)),
+                productRepository.save(getProductAndSave("002","품목2", group, customer)),
+                productRepository.save(getProductAndSave("003","품목3", group, customer))
+        );
+
+        // when
+        List<ProductSummaryResponse> products = productService.getAllProducts();
+
+        // then
+        assertEquals(savedProducts.size(), products.size());
+
+        for (int i = 0; i < savedProducts.size(); i++) {
+            Product expected = savedProducts.get(i);
+            ProductSummaryResponse actual = products.get(i);
+
+            assertEquals(expected.getId(), actual.getId());
+            assertEquals(expected.getImgUrl(), actual.getImgUrl());
+            assertEquals(expected.getCode(), actual.getCode());
+            assertEquals(expected.getName(), actual.getName());
+            assertEquals(expected.getSpec(), actual.getSpec());
+            assertEquals(expected.getBoxQuantity(), actual.getBoxQuantity());
+            assertEquals(expected.getProductGroup().getId(), actual.getProductGroup().getId());
+            assertEquals(expected.getProductGroup().getName(), actual.getProductGroup().getName());
+            assertEquals(expected.getCustomer().getId(), actual.getCustomer().getId());
+            assertEquals(expected.getCustomer().getBizName(), actual.getCustomer().getName());
+            assertEquals(expected.getTaxType().toString(), actual.getTaxType());
+            assertEquals(expected.getDistChannel().toString(), actual.getDistChannel());
+            assertEquals(expected.getSalePrice(), actual.getSalePrice());
+        }
+    }
+
+
+    @Test
+    void 품목_상세_조회(){
+        //given
+        Customer customer = customerRepository.save(getCustomer());
+        ProductGroup group = productGroupRepository.save(new ProductGroup("테스트 그룹"));
+        Product product = getProductAndSave("001", "name", group, customer); //나중에 null일때도 테스트
+
+        //when
+        ProductDetailResponse response = productService.getProduct(product.getId());
+
+        //then
+        assertEquals(product.getId(), response.getId());
+        assertEquals(product.getImgUrl(), response.getImgUrl());
+        assertEquals(product.getCode(), response.getCode());
+        assertEquals(product.getName(), response.getName());
+        assertEquals(product.getSpec(), response.getSpec());
+        assertEquals(product.getBoxQuantity(), response.getBoxQuantity());
+        assertEquals(product.getProductGroup().getId(), response.getProductGroup().getId());
+        assertEquals(product.getProductGroup().getName(), response.getProductGroup().getName());
+        assertEquals(product.getCustomer().getId(), response.getCustomer().getId());
+        assertEquals(product.getCustomer().getBizName(), response.getCustomer().getName());
+        assertEquals(product.getTaxType(), response.getTaxType());
+        assertEquals(product.getDistChannel(), response.getDistChannel());
+        assertEquals(product.getPurchasePrice(), response.getPurchasePrice());
+        assertEquals(product.getSalePrice(), response.getSalePrice());
+        assertEquals(product.getMemo(), response.getMemo());
+    }
+
+
+    @Test
+    void 품목_논리_삭제(){
+        //given
+        Product product = getProductAndSave("001", "품목1", null, null);
+
+        //when
+        productService.deleteProduct(product.getId());
+
+        //then
+        Product deletedProduct = productRepository.findById(product.getId()).orElseThrow();
+        assertTrue(deletedProduct.isDeleted());
+    }
+
+
 
     /**
          그룹 생성 createGroup()
@@ -78,7 +356,7 @@ class ProductServiceTest {
 
 
     @Test
-    void 그룹_생성_삭제된_이름_중복허용(){
+    void 그룹_생성_논리삭제된_이름_중복허용(){
         //given
         CreateProductGroupRequest request = new CreateProductGroupRequest("농약");
         CreateProductGroupRequest requestDuplicateName = new CreateProductGroupRequest("농약");
@@ -133,6 +411,7 @@ class ProductServiceTest {
         assertTrue(group.isDeleted());
     }
 
+
     @Test
     void 그룹_삭제_품목존재시_불가(){
         //given
@@ -146,6 +425,116 @@ class ProductServiceTest {
         product.delete();
         //then - 그룹에 속한 품목이 없어서 삭제 가능!
         productService.deleteGroup(group.getId());
+    }
+
+
+    /**
+     * 기타 유틸 메소드
+     */
+
+    //Customer 생성
+    private Customer getCustomer() {
+        return new Customer(
+                CustomerType.CORPORATION, // 사업자 유형
+                SalesGroup.NONGHYUP,     // 영업 분류
+                "123456-0000000",         // corpNo
+                "123-45-67890",           // bizNo
+                null,                     // rrn (개인만)
+                "그린아그로",               // bizName
+                "홍길동",                   // ceoName
+                "도소매",                   // bizType
+                "농자재",                   // bizItem
+                "02-123-4567",             // tel
+                "010-1234-5678",           // phone
+                "서울시 강남구 테헤란로 1",  // addressMain
+                "서울시 강남구 봉은사로 2",  // addressSub
+                "02-987-6543",             // fax
+                "test@example.com",        // email
+                "김우리",                   // ourManager
+                "이거래",                   // customerManager
+                "테스트 메모"
+        );
+    }
+
+    //Customer 생성
+    private Customer getCustomer2() {
+        return new Customer(
+                CustomerType.SOLE_PROPRIETOR, // 사업자 유형
+                SalesGroup.LANDSCAPE,     // 영업 분류
+                "123456-0000000-2",         // corpNo
+                "123-45-67890-2",           // bizNo
+                null,                     // rrn (개인만)
+                "그린아그로-2",               // bizName
+                "홍길동-2",                   // ceoName
+                "도소매-2",                   // bizType
+                "농자재-2",                   // bizItem
+                "02-123-4567-2",             // tel
+                "010-1234-5678-2",           // phone
+                "서울시 강남구 테헤란로 1-2",  // addressMain
+                "서울시 강남구 봉은사로 2-2",  // addressSub
+                "02-987-6543-2",             // fax
+                "test@example.com-2",        // email
+                "김우리-2",                   // ourManager
+                "이거래-2",                   // customerManager
+                "테스트 메모-2"
+        );
+    }
+
+
+    private CreateProductRequest getCreateProductRequest(String code, String name,ProductGroup group, Customer customer) {
+        return new CreateProductRequest(
+                "https://example.com/image.jpg", // imgUrl
+                code,                          // code
+                name,                           // name
+                "spec",                         // spec
+                10L,                             // boxQuantity
+                group != null ? group.getId() : null,                   // productGroupId
+                customer != null ? customer.getId() : null,                // customerId
+                TaxType.TAXED,                   // taxType
+                DistChannel.DIRECT,              // distChannel
+                5000L,                           // purchasePrice
+                8000L,                           // salePrice
+                "테스트 메모"                      // memo
+        );
+    }
+
+
+    private UpdateProductRequest getUpdateProductRequest(String code, String name, ProductGroup group, Customer customer) {
+        return new UpdateProductRequest(
+                "https://example.com/image.jpg-2", // imgUrl
+                code,                          // code
+                name,                     // name
+                "spec-2",                         // spec
+                20L,                             // boxQuantity
+                group != null ? group.getId() : null,                   // productGroupId
+                customer != null ? customer.getId() : null,                // customerId
+                TaxType.NON_TAX,                   // taxType
+                DistChannel.NON_COOP,              // distChannel
+                9000L,                           // purchasePrice
+                10000L,                           // salePrice
+                "테스트 메모-2"                      // memo
+        );
+    }
+
+
+    private Product getProductAndSave(String code, String name, ProductGroup group, Customer customer) {
+
+        Product product = new Product(
+                "https://example.com/image.jpg",
+                code,
+                name,
+                "10L",
+                10L,
+                group,
+                customer,
+                TaxType.TAXED,
+                DistChannel.DIRECT,
+                5000L,
+                8000L,
+                "테스트 메모"
+        );
+
+        return productRepository.save(product);
     }
 
 }


### PR DESCRIPTION
## ✅ 작업 내용

-품목, 품목그룹 관련 기본 CRUD 구현 완료

### 도메인 모델 구현
- `Product`
- `ProductGroup`

### API 구현
- **품목(Product) API**
  - 품목 생성 (`POST /products`)
  - 품목 전체 조회 (`GET /products`)
  - 품목 단건 조회 (`GET /products/{id}`)
  - 품목 수정 (`PUT /products/{id}`)
  - 품목 삭제 (`DELETE /products/{id}`)

- **그룹(ProductGroup) API**
  - 그룹 생성 (`POST /product-groups`)
  - 그룹 전체조회 (`GET /product-groups`)
  - 그룹 수정 (`PUT /product-groupss/{id}`)
  - 그룹 삭제 (`DELETE /product-groups/{id}`)
 

### 테스트 코드 작성
- ProductServiceTest : 품목, 그룹 CRUD 테스트

